### PR TITLE
[RedDwarf] Implement player entity, animations, and grid-step movement with collision tests

### DIFF
--- a/src/game/Player.ts
+++ b/src/game/Player.ts
@@ -1,0 +1,57 @@
+import Phaser from "phaser";
+import type { GridDirection } from "../systems/GridMovement";
+
+const DIRECTION_ROW: Record<GridDirection, number> = {
+  down: 0,
+  left: 1,
+  right: 2,
+  up: 3,
+};
+
+export class Player extends Phaser.GameObjects.Sprite {
+  constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
+    super(scene, x, y, texture, 0);
+    scene.add.existing(this);
+    this.setOrigin(0.5, 0.75);
+    this.setDepth(2);
+  }
+
+  static createAnimations(scene: Phaser.Scene, texture: string): void {
+    const animationManager = scene.anims;
+
+    for (const [direction, row] of Object.entries(DIRECTION_ROW) as [GridDirection, number][]) {
+      const start = row * 4;
+      const idleKey = `player-idle-${direction}`;
+      const walkKey = `player-walk-${direction}`;
+
+      if (!animationManager.exists(idleKey)) {
+        animationManager.create({
+          key: idleKey,
+          frames: [{ key: texture, frame: start }],
+          frameRate: 1,
+          repeat: -1,
+        });
+      }
+
+      if (!animationManager.exists(walkKey)) {
+        animationManager.create({
+          key: walkKey,
+          frames: animationManager.generateFrameNumbers(texture, {
+            start,
+            end: start + 3,
+          }),
+          frameRate: 10,
+          repeat: -1,
+        });
+      }
+    }
+  }
+
+  face(direction: GridDirection): void {
+    this.play(`player-idle-${direction}`, true);
+  }
+
+  walk(direction: GridDirection): void {
+    this.play(`player-walk-${direction}`, true);
+  }
+}

--- a/src/scenes/HelloFarmScene.ts
+++ b/src/scenes/HelloFarmScene.ts
@@ -1,13 +1,33 @@
 import Phaser from "phaser";
 import { FONT_FAMILY, GAME_HEIGHT, GAME_WIDTH } from "../config/constants";
+import { Player } from "../game/Player";
+import {
+  finishGridMove,
+  type GridDirection,
+  type GridMoveState,
+  type GridPosition,
+  GRID_STEP_MS,
+  toWorldPosition,
+  tryStartGridMove,
+} from "../systems/GridMovement";
 
 const MAP_KEY = "farm-map";
 const GRASS_TILESET_KEY = "farm-tiles-grass";
 const FENCE_TILESET_KEY = "farm-tiles-fences";
 const WATER_TILESET_KEY = "farm-tiles-water";
 const PLAYER_SPRITESHEET_KEY = "farm-player";
+const DEFAULT_PLAYER_TILE: GridPosition = { x: 2, y: 2 };
 
 export class HelloFarmScene extends Phaser.Scene {
+  private player?: Player;
+  private collisionLayer?: Phaser.Tilemaps.TilemapLayer;
+  private movementState: GridMoveState = {
+    position: DEFAULT_PLAYER_TILE,
+    facing: "down",
+    isMoving: false,
+  };
+  private movementKeys?: Record<string, Phaser.Input.Keyboard.Key>;
+
   constructor() {
     super("hello-farm");
   }
@@ -35,12 +55,34 @@ export class HelloFarmScene extends Phaser.Scene {
     map.createLayer("Ground", tilesets);
     map.createLayer("Decor", tilesets);
 
-    const collisionLayer = map.createLayer("Collision", tilesets);
-    collisionLayer?.setVisible(false);
-    collisionLayer?.setCollisionByExclusion([-1, 0]);
+    this.collisionLayer = map.createLayer("Collision", tilesets) ?? undefined;
+    this.collisionLayer?.setVisible(false);
+    this.collisionLayer?.setCollisionByExclusion([-1, 0]);
 
-    const player = this.add.sprite(120, 96, PLAYER_SPRITESHEET_KEY, 0);
-    player.setDepth(2);
+    Player.createAnimations(this, PLAYER_SPRITESHEET_KEY);
+
+    const spawnTile = this.findOpenSpawnTile(map);
+    const spawnPosition = toWorldPosition(spawnTile, map.tileWidth, map.tileHeight);
+
+    this.movementState = {
+      position: spawnTile,
+      facing: "down",
+      isMoving: false,
+    };
+
+    this.player = new Player(this, spawnPosition.x, spawnPosition.y, PLAYER_SPRITESHEET_KEY);
+    this.player.face(this.movementState.facing);
+
+    this.movementKeys = this.input.keyboard?.addKeys({
+      up: Phaser.Input.Keyboard.KeyCodes.UP,
+      down: Phaser.Input.Keyboard.KeyCodes.DOWN,
+      left: Phaser.Input.Keyboard.KeyCodes.LEFT,
+      right: Phaser.Input.Keyboard.KeyCodes.RIGHT,
+      w: Phaser.Input.Keyboard.KeyCodes.W,
+      a: Phaser.Input.Keyboard.KeyCodes.A,
+      s: Phaser.Input.Keyboard.KeyCodes.S,
+      d: Phaser.Input.Keyboard.KeyCodes.D,
+    }) as Record<string, Phaser.Input.Keyboard.Key> | undefined;
 
     const interactables = map.getObjectLayer("Interactables");
     const sign = interactables?.objects[0];
@@ -69,6 +111,113 @@ export class HelloFarmScene extends Phaser.Scene {
       .setDepth(3);
 
     this.cameras.main.setBounds(0, 0, map.widthInPixels, map.heightInPixels);
-    this.cameras.main.centerOn(map.widthInPixels / 2, map.heightInPixels / 2);
+    this.cameras.main.startFollow(this.player, true);
+    this.cameras.main.roundPixels = true;
+  }
+
+  update(): void {
+    const direction = this.getJustPressedDirection();
+    if (direction) {
+      this.handleMoveRequest(direction);
+    }
+  }
+
+  private getJustPressedDirection(): GridDirection | undefined {
+    const keys = this.movementKeys;
+    if (!keys) {
+      return undefined;
+    }
+
+    const justPressed = (...inputKeys: Array<Phaser.Input.Keyboard.Key | undefined>): boolean => {
+      for (const key of inputKeys) {
+        if (key && Phaser.Input.Keyboard.JustDown(key)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    if (justPressed(keys.left, keys.a)) {
+      return "left";
+    }
+    if (justPressed(keys.right, keys.d)) {
+      return "right";
+    }
+    if (justPressed(keys.up, keys.w)) {
+      return "up";
+    }
+    if (justPressed(keys.down, keys.s)) {
+      return "down";
+    }
+
+    return undefined;
+  }
+
+  private handleMoveRequest(direction: GridDirection): void {
+    const player = this.player;
+    const collisionLayer = this.collisionLayer;
+
+    if (!player || !collisionLayer) {
+      return;
+    }
+
+    const result = tryStartGridMove(
+      this.movementState,
+      direction,
+      { width: collisionLayer.layer.width, height: collisionLayer.layer.height },
+      (position) => collisionLayer.hasTileAt(position.x, position.y)
+    );
+
+    this.movementState = result.nextState;
+
+    if (!result.moveTo) {
+      player.face(this.movementState.facing);
+      return;
+    }
+
+    const targetPosition = toWorldPosition(result.moveTo, collisionLayer.tilemap.tileWidth, collisionLayer.tilemap.tileHeight);
+    player.walk(this.movementState.facing);
+
+    this.tweens.add({
+      targets: player,
+      x: targetPosition.x,
+      y: targetPosition.y,
+      duration: GRID_STEP_MS,
+      ease: "Sine.Out",
+      onComplete: () => {
+        this.movementState = finishGridMove(this.movementState);
+        player.face(this.movementState.facing);
+
+        const queuedDirection = this.movementState.queuedDirection;
+        if (queuedDirection) {
+          this.movementState = { ...this.movementState, queuedDirection: undefined };
+          this.handleMoveRequest(queuedDirection);
+        }
+      },
+    });
+  }
+
+  private findOpenSpawnTile(map: Phaser.Tilemaps.Tilemap): GridPosition {
+    const fallback = DEFAULT_PLAYER_TILE;
+    const collisionLayer = map.getLayer("Collision")?.tilemapLayer;
+
+    if (!collisionLayer) {
+      return fallback;
+    }
+
+    if (!collisionLayer.hasTileAt(fallback.x, fallback.y)) {
+      return fallback;
+    }
+
+    for (let y = 0; y < map.height; y += 1) {
+      for (let x = 0; x < map.width; x += 1) {
+        if (!collisionLayer.hasTileAt(x, y)) {
+          return { x, y };
+        }
+      }
+    }
+
+    return fallback;
   }
 }

--- a/src/systems/GridMovement.ts
+++ b/src/systems/GridMovement.ts
@@ -1,0 +1,106 @@
+export type GridDirection = "up" | "down" | "left" | "right";
+
+export interface GridPosition {
+  x: number;
+  y: number;
+}
+
+export interface GridBounds {
+  width: number;
+  height: number;
+}
+
+export interface GridMoveState {
+  position: GridPosition;
+  facing: GridDirection;
+  isMoving: boolean;
+  queuedDirection?: GridDirection;
+}
+
+export interface GridMoveResult {
+  nextState: GridMoveState;
+  moveTo?: GridPosition;
+  blocked: boolean;
+}
+
+export const GRID_STEP_MS = 180;
+
+const DIRECTION_VECTORS: Record<GridDirection, GridPosition> = {
+  up: { x: 0, y: -1 },
+  down: { x: 0, y: 1 },
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+};
+
+export function getTargetTile(position: GridPosition, direction: GridDirection): GridPosition {
+  const vector = DIRECTION_VECTORS[direction];
+  return {
+    x: position.x + vector.x,
+    y: position.y + vector.y,
+  };
+}
+
+export function isWithinBounds(position: GridPosition, bounds: GridBounds): boolean {
+  return position.x >= 0 && position.y >= 0 && position.x < bounds.width && position.y < bounds.height;
+}
+
+export function toWorldPosition(position: GridPosition, tileWidth: number, tileHeight = tileWidth): GridPosition {
+  return {
+    x: position.x * tileWidth + tileWidth / 2,
+    y: position.y * tileHeight + tileHeight / 2,
+  };
+}
+
+export function queueDirection(state: GridMoveState, direction: GridDirection): GridMoveState {
+  return {
+    ...state,
+    facing: direction,
+    queuedDirection: direction,
+  };
+}
+
+export function tryStartGridMove(
+  state: GridMoveState,
+  direction: GridDirection,
+  bounds: GridBounds,
+  isBlocked: (position: GridPosition) => boolean
+): GridMoveResult {
+  if (state.isMoving) {
+    return {
+      nextState: queueDirection(state, direction),
+      blocked: false,
+    };
+  }
+
+  const target = getTargetTile(state.position, direction);
+  const blocked = !isWithinBounds(target, bounds) || isBlocked(target);
+
+  if (blocked) {
+    return {
+      nextState: {
+        ...state,
+        facing: direction,
+        queuedDirection: undefined,
+      },
+      blocked: true,
+    };
+  }
+
+  return {
+    nextState: {
+      position: target,
+      facing: direction,
+      isMoving: true,
+      queuedDirection: undefined,
+    },
+    moveTo: target,
+    blocked: false,
+  };
+}
+
+export function finishGridMove(state: GridMoveState): GridMoveState {
+  return {
+    ...state,
+    isMoving: false,
+  };
+}

--- a/tests/GridMovement.test.ts
+++ b/tests/GridMovement.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  finishGridMove,
+  getTargetTile,
+  queueDirection,
+  toWorldPosition,
+  tryStartGridMove,
+} from "../src/systems/GridMovement";
+
+describe("GridMovement", () => {
+  it("computes the next tile for a direction", () => {
+    expect(getTargetTile({ x: 4, y: 5 }, "left")).toEqual({ x: 3, y: 5 });
+    expect(getTargetTile({ x: 4, y: 5 }, "up")).toEqual({ x: 4, y: 4 });
+  });
+
+  it("converts a tile to centered world coordinates", () => {
+    expect(toWorldPosition({ x: 2, y: 3 }, 16)).toEqual({ x: 40, y: 56 });
+  });
+
+  it("starts a successful move into an open tile", () => {
+    const result = tryStartGridMove(
+      { position: { x: 2, y: 2 }, facing: "down", isMoving: false },
+      "right",
+      { width: 20, height: 12 },
+      () => false
+    );
+
+    expect(result.blocked).toBe(false);
+    expect(result.moveTo).toEqual({ x: 3, y: 2 });
+    expect(result.nextState).toEqual({
+      position: { x: 3, y: 2 },
+      facing: "right",
+      isMoving: true,
+      queuedDirection: undefined,
+    });
+  });
+
+  it("rejects a blocked move without changing tile position", () => {
+    const result = tryStartGridMove(
+      { position: { x: 2, y: 2 }, facing: "down", isMoving: false },
+      "up",
+      { width: 20, height: 12 },
+      (position) => position.x === 2 && position.y === 1
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.moveTo).toBeUndefined();
+    expect(result.nextState.position).toEqual({ x: 2, y: 2 });
+    expect(result.nextState.facing).toBe("up");
+  });
+
+  it("queues the next direction while a move is already in progress", () => {
+    const movingState = {
+      position: { x: 2, y: 2 },
+      facing: "down" as const,
+      isMoving: true,
+    };
+
+    expect(queueDirection(movingState, "left").queuedDirection).toBe("left");
+
+    const result = tryStartGridMove(movingState, "left", { width: 20, height: 12 }, () => false);
+    expect(result.blocked).toBe(false);
+    expect(result.moveTo).toBeUndefined();
+    expect(result.nextState.queuedDirection).toBe("left");
+    expect(finishGridMove(result.nextState).isMoving).toBe(false);
+  });
+});


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-webhook-testbed-10-ticket-4
- Run ID: 404140a6-47ac-42a2-a773-96c22787783b
- Base branch: main
- Head branch: reddwarf/derekrivers-webhook-testbed-10-ticket-4/scm
- Validation report: workspace://derekrivers-webhook-testbed-10-ticket-4-workspace/artifacts/validation-report.md

### Summary

Introduce a `Player` entity and supporting input and movement systems to render a controllable character on the farm map. The movement model should be tile-based rather than free movement: each input advances exactly one tile, movement is tweened over a fixed step duration, and new inputs are queued or rejected cleanly while a step is in progress. Keep the movement math and collision decision logic as pure functions where practical in `src/systems/GridMovement.ts`, so unit tests can validate direction handling, tile targeting, blocked moves, and queue behavior independently of Phaser. Add four-directional idle and walk animations tied to the player’s facing state.

### Validation

Run deterministic lint and test checks for workspace derekrivers-webhook-testbed-10-ticket-4-workspace before review or SCM handoff.

### Acceptance Criteria

- The player sprite is spawned into the farm scene at a valid grid position.
- Four-directional walk animations exist, and idle state preserves the most recent facing direction.
- Arrow keys and WASD trigger one-tile movement only, with tweened transitions rather than instant teleportation.
- Collision-layer tiles prevent movement into blocked positions without jitter or partial overlap.
- Movement logic is factored so pure helpers can be unit tested outside the scene runtime.
- Unit tests cover core movement math, including at least successful moves and blocked moves.

<!-- reddwarf:ticket_id:project:derekrivers-webhook-testbed-10:ticket:4 -->
