### PR TITLE
[RedDwarf] Add camera follow, interaction system, and gameplay proof-of-concept polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A typical local workflow looks like this:
 
 1. Run `npm install` after cloning or when dependencies change.
 2. Use `npm run dev` while iterating on game code in `src/`.
-3. Before opening a change for review, run:
+3. Before opening a change for review, run the full validation set:
    ```bash
    npm run lint
    npm run format:check
@@ -43,6 +43,14 @@ A typical local workflow looks like this:
    npm run build
    ```
 4. If formatting fails, run `npm run format`, then re-run the checks.
+
+## Playable slice behavior
+
+- Move one tile at a time with the arrow keys or `W`, `A`, `S`, `D`.
+- The camera follows the player and stays clamped to the farm map bounds.
+- Press `E` to check the tile directly in front of the player based on their current facing direction.
+- The authored sign in the farm map is registered as an interactable proof of concept and logs a recognizable message to the browser console.
+- Pressing `E` when no interactable is in front of the player does nothing.
 
 ## What is included
 
@@ -63,6 +71,7 @@ See `assets/LICENSE` for source links, license notes, and required credit.
 - Open `assets/maps/farm.tmj` directly in Tiled.
 - The map uses relative image paths into `assets/tilesets/`, so the checked-in tilesets resolve without extra setup.
 - The interactable sign hook is stored in the `Interactables` object layer.
+- Add new interaction targets in that object layer and keep them aligned to the tile grid so the interaction registry can resolve them cleanly.
 - The blocking tiles are represented in the `Collision` layer.
 
 ## Next steps

--- a/src/scenes/HelloFarmScene.ts
+++ b/src/scenes/HelloFarmScene.ts
@@ -10,6 +10,13 @@ import {
   toWorldPosition,
   tryStartGridMove,
 } from "../systems/GridMovement";
+import {
+  createInteractableRegistry,
+  createInteractionKey,
+  getFacingTile,
+  objectToTilePosition,
+  type InteractableEntry,
+} from "../systems/interaction";
 
 const MAP_KEY = "farm-map";
 const GRASS_TILESET_KEY = "farm-tiles-grass";
@@ -27,6 +34,8 @@ export class HelloFarmScene extends Phaser.Scene {
     isMoving: false,
   };
   private movementKeys?: Record<string, Phaser.Input.Keyboard.Key>;
+  private interactKey?: Phaser.Input.Keyboard.Key;
+  private interactables = new Map<string, InteractableEntry>();
 
   constructor() {
     super("hello-farm");
@@ -83,12 +92,27 @@ export class HelloFarmScene extends Phaser.Scene {
       s: Phaser.Input.Keyboard.KeyCodes.S,
       d: Phaser.Input.Keyboard.KeyCodes.D,
     }) as Record<string, Phaser.Input.Keyboard.Key> | undefined;
+    this.interactKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.E);
 
-    const interactables = map.getObjectLayer("Interactables");
-    const sign = interactables?.objects[0];
+    const interactableObjects = map.getObjectLayer("Interactables")?.objects ?? [];
+    const sign = interactableObjects[0];
     const prompt = sign?.properties?.find(
       (property: { name: string; value: unknown }) => property.name === "prompt"
     )?.value;
+
+    this.interactables = createInteractableRegistry(
+      interactableObjects
+        .filter((object) => object.type === "sign")
+        .map((object) => ({
+          position: objectToTilePosition(object, map.tileWidth, map.tileHeight),
+          interact: () => {
+            const name = object.name || "interactable";
+            globalThis.console.log(
+              `[interaction] ${name}: Farm sign says hello from the playable slice.`
+            );
+          },
+        }))
+    );
 
     this.add
       .text(8, 8, "Farm slice loaded", {
@@ -101,7 +125,7 @@ export class HelloFarmScene extends Phaser.Scene {
       .setDepth(3);
 
     this.add
-      .text(8, GAME_HEIGHT - 24, typeof prompt === "string" ? prompt : "Interactable hook ready.", {
+      .text(8, GAME_HEIGHT - 24, typeof prompt === "string" ? `Move with arrows/WASD, press E to interact. ${prompt}` : "Move with arrows/WASD, press E to interact.", {
         color: "#16351a",
         fontFamily: FONT_FAMILY,
         fontSize: "10px",
@@ -116,6 +140,10 @@ export class HelloFarmScene extends Phaser.Scene {
   }
 
   update(): void {
+    if (this.interactKey && Phaser.Input.Keyboard.JustDown(this.interactKey)) {
+      this.tryInteract();
+    }
+
     const direction = this.getJustPressedDirection();
     if (direction) {
       this.handleMoveRequest(direction);
@@ -196,6 +224,12 @@ export class HelloFarmScene extends Phaser.Scene {
         }
       },
     });
+  }
+
+  private tryInteract(): void {
+    const interactionTile = getFacingTile(this.movementState.position, this.movementState.facing);
+    const interactable = this.interactables.get(createInteractionKey(interactionTile));
+    interactable?.interact();
   }
 
   private findOpenSpawnTile(map: Phaser.Tilemaps.Tilemap): GridPosition {

--- a/src/systems/interaction.ts
+++ b/src/systems/interaction.ts
@@ -1,0 +1,48 @@
+import type Phaser from "phaser";
+
+export type FacingDirection = "up" | "down" | "left" | "right";
+
+export interface TilePosition {
+  x: number;
+  y: number;
+}
+
+export interface InteractableEntry {
+  position: TilePosition;
+  interact: () => void;
+}
+
+export function getFacingTile(position: TilePosition, facing: FacingDirection): TilePosition {
+  switch (facing) {
+    case "up":
+      return { x: position.x, y: position.y - 1 };
+    case "down":
+      return { x: position.x, y: position.y + 1 };
+    case "left":
+      return { x: position.x - 1, y: position.y };
+    case "right":
+      return { x: position.x + 1, y: position.y };
+  }
+}
+
+export function createInteractionKey(position: TilePosition): string {
+  return `${position.x},${position.y}`;
+}
+
+export function objectToTilePosition(
+  object: Phaser.Types.Tilemaps.TiledObject,
+  tileWidth: number,
+  tileHeight: number
+): TilePosition {
+  const x = object.x ?? 0;
+  const y = object.y ?? 0;
+
+  return {
+    x: Math.floor(x / tileWidth),
+    y: Math.floor((y - (object.height ?? tileHeight)) / tileHeight),
+  };
+}
+
+export function createInteractableRegistry(entries: InteractableEntry[]): Map<string, InteractableEntry> {
+  return new Map(entries.map((entry) => [createInteractionKey(entry.position), entry]));
+}

--- a/tests/interaction.test.ts
+++ b/tests/interaction.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createInteractableRegistry,
+  createInteractionKey,
+  getFacingTile,
+  objectToTilePosition,
+} from "../src/systems/interaction";
+
+describe("interaction helpers", () => {
+  it("computes the tile in front of the player for each facing direction", () => {
+    const position = { x: 5, y: 6 };
+
+    expect(getFacingTile(position, "up")).toEqual({ x: 5, y: 5 });
+    expect(getFacingTile(position, "down")).toEqual({ x: 5, y: 7 });
+    expect(getFacingTile(position, "left")).toEqual({ x: 4, y: 6 });
+    expect(getFacingTile(position, "right")).toEqual({ x: 6, y: 6 });
+  });
+
+  it("maps tiled object coordinates onto a grid tile", () => {
+    expect(
+      objectToTilePosition(
+        { x: 176, y: 112, width: 16, height: 16 } as never,
+        16,
+        16
+      )
+    ).toEqual({ x: 11, y: 6 });
+  });
+
+  it("registers and resolves interactables by tile key", () => {
+    const interact = vi.fn();
+    const registry = createInteractableRegistry([{ position: { x: 11, y: 6 }, interact }]);
+
+    registry.get(createInteractionKey({ x: 11, y: 6 }))?.interact();
+    registry.get(createInteractionKey({ x: 0, y: 0 }))?.interact();
+
+    expect(interact).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-webhook-testbed-10-ticket-5
- Run ID: 04edc575-baaa-4e72-a8ea-24208c2ff979
- Base branch: main
- Head branch: reddwarf/derekrivers-webhook-testbed-10-ticket-5/scm
- Validation report: workspace://derekrivers-webhook-testbed-10-ticket-5-workspace/artifacts/validation-report.md

### Summary

Finish the first playable slice by wiring the Phaser camera to follow the player while clamping to the map bounds, then add a minimal interaction system that computes the tile in front of the player based on facing direction and dispatches actions through a small interactable registry. Connect the authored sign tile or object from the farm map to a recognizable console log so the interaction loop can be demonstrated immediately, and add unit coverage for facing-tile calculation. Use this ticket to complete README details around gameplay behavior and final validation commands so the repository is ready for follow-up systems such as farming, time, and inventory.

### Validation

Run deterministic lint and test checks for workspace derekrivers-webhook-testbed-10-ticket-5-workspace before review or SCM handoff.

### Acceptance Criteria

- The camera follows the player and stays clamped to map bounds without exposing black edges beyond the farm.
- Pressing `E` checks the tile in front of the player based on current facing direction.
- Interacting with the authored sign or equivalent map object logs a recognizable proof-of-concept message.
- Pressing `E` when no interactable is present produces no unintended side effects.
- Unit tests cover facing-tile calculation for all relevant directions.
- README includes how the playable slice works, how to edit the map, and how to run the full validation command set.

<!-- reddwarf:ticket_id:project:derekrivers-webhook-testbed-10:ticket:5 -->
