### PR TITLE
[RedDwarf] Test System Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # webhook-testbed
 
-A Vite + TypeScript + Phaser 3 starter for the farm-game prototype work in this repository.
+A Vite + TypeScript + Phaser 3 prototype for a small top-down farm slice.
+
+## Project overview
+
+This repository currently ships a single playable scene centered on tile-based movement and map-driven interaction.
+
+- Move one tile at a time with the arrow keys or `W`, `A`, `S`, `D`.
+- The camera follows the player and stays clamped to the farm map bounds.
+- Collision comes from the Tiled `Collision` layer, so blocked tiles are authored in the map instead of hard-coded in the scene.
+- Press `E` to inspect the tile directly in front of the player based on their current facing direction.
+- Interactions are resolved from the Tiled `Interactables` object layer. The current proof of concept is a sign that logs a message to the browser console.
+
+The current gameplay lives in `src/scenes/HelloFarmScene.ts` and is configured through shared constants and helper systems rather than scene-local one-off logic.
 
 ## Prerequisites
 
@@ -20,7 +32,7 @@ A Vite + TypeScript + Phaser 3 starter for the farm-game prototype work in this 
 
 ## Available scripts
 
-- `npm run dev` starts the Vite development server.
+- `npm run dev` starts the Vite development server for moment-to-moment gameplay iteration.
 - `npm run build` runs a TypeScript no-emit check and creates a production build with Vite.
 - `npm run lint` checks the TypeScript codebase with ESLint.
 - `npm run format` formats the repository with Prettier.
@@ -33,8 +45,9 @@ A Vite + TypeScript + Phaser 3 starter for the farm-game prototype work in this 
 A typical local workflow looks like this:
 
 1. Run `npm install` after cloning or when dependencies change.
-2. Use `npm run dev` while iterating on game code in `src/`.
-3. Before opening a change for review, run the full validation set:
+2. Use `npm run dev` while iterating on scene logic, systems, or map data.
+3. Run `npm run test` and `npm run typecheck` during implementation when you want quick validation.
+4. Before handing off a change, run the broader verification set:
    ```bash
    npm run lint
    npm run format:check
@@ -42,38 +55,46 @@ A typical local workflow looks like this:
    npm run typecheck
    npm run build
    ```
-4. If formatting fails, run `npm run format`, then re-run the checks.
+5. If formatting fails, run `npm run format`, then re-run the checks.
 
-## Playable slice behavior
+## Project structure
 
-- Move one tile at a time with the arrow keys or `W`, `A`, `S`, `D`.
-- The camera follows the player and stays clamped to the farm map bounds.
-- Press `E` to check the tile directly in front of the player based on their current facing direction.
-- The authored sign in the farm map is registered as an interactable proof of concept and logs a recognizable message to the browser console.
-- Pressing `E` when no interactable is in front of the player does nothing.
+- `src/main.ts` boots the Phaser application into the page.
+- `src/game/config.ts` defines the Phaser game configuration, renderer settings, scene list, scaling, and post-boot canvas setup.
+- `src/config/constants.ts` stores shared sizing, zoom, and UI constants.
+- `src/scenes/` contains scene implementations, including the current playable slice in `HelloFarmScene.ts`.
+- `src/systems/GridMovement.ts` owns tile-step movement rules, queueing, bounds checks, and world-position conversion.
+- `src/systems/interaction.ts` converts Tiled objects into tile coordinates and resolves interactables by facing tile.
+- `tests/` contains Vitest coverage for the project test harness and future gameplay/unit tests.
+- `assets/` stores the checked-in Tiled map, tilesets, sprites, and asset licensing notes.
 
-## What is included
+## Current playable slice
 
-- Vite app bootstrap with TypeScript entrypoints under `src/`
-- Strict TypeScript compiler settings
-- Phaser game bootstrapping from `src/main.ts`
-- Shared constants and game config modules for later farm-scene expansion
-- A trivial Vitest unit test under `tests/` to validate the test harness
-- A farm-scene pipeline that preloads a Tiled TMJ map, Sprout Lands tilesets, and a player spritesheet
+The playable slice is intentionally small, but the current implementation already demonstrates the core loop the rest of the prototype can build on:
+
+- `HelloFarmScene` loads `assets/maps/farm.tmj` plus the Sprout Lands tilesets and player spritesheet.
+- The player spawns on an open tile, faces the requested direction immediately, and moves in timed grid steps.
+- Input buffering is supported through the grid movement state, so a new direction can be queued while a move tween is still finishing.
+- The scene hides the collision layer visually, while still using it to block movement.
+- A HUD-style text prompt reminds the player of the movement and interaction controls, and the map-authored prompt is appended when available.
+
+## Editing the farm map
+
+The current gameplay depends heavily on the Tiled map, so README-level map guidance is worth keeping close to the code:
+
+- Open `assets/maps/farm.tmj` directly in Tiled.
+- The map uses relative paths into `assets/tilesets/`, so the checked-in tilesets resolve without extra setup.
+- The `Ground` and `Decor` layers control the visible farm layout.
+- The `Collision` layer defines blocked tiles. Scene movement checks `hasTileAt(...)` on that layer to decide whether a move is valid.
+- The `Interactables` object layer defines things the player can use with `E`.
+- Interactable objects should stay aligned to the tile grid because the interaction system converts object coordinates into tile coordinates before building the registry.
+- The current sample object is the `farm-sign` sign, which demonstrates the interaction flow and prompt text plumbing.
 
 ## Asset sourcing
 
 The current playable slice uses art from the free Sprout Lands Basic pack by Cup Nooble.
 See `assets/LICENSE` for source links, license notes, and required credit.
 
-## Editing the farm map
+## Current limitations / next steps
 
-- Open `assets/maps/farm.tmj` directly in Tiled.
-- The map uses relative image paths into `assets/tilesets/`, so the checked-in tilesets resolve without extra setup.
-- The interactable sign hook is stored in the `Interactables` object layer.
-- Add new interaction targets in that object layer and keep them aligned to the tile grid so the interaction registry can resolve them cleanly.
-- The blocking tiles are represented in the `Collision` layer.
-
-## Next steps
-
-Later tickets can add gameplay systems, movement, interaction handling, additional scenes, and fuller project documentation.
+This is still an early prototype. The repository does not yet include systems like inventory, farming actions, save data, dialogue UI, or multiple playable areas. The current codebase is best understood as a clean vertical slice for movement, map loading, camera behavior, and map-authored interaction rather than a complete game loop.


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-webhook-testbed-21
- Run ID: d4902c03-e381-41ab-a6ea-d53b7cb0cad7
- Base branch: main
- Head branch: reddwarf/derekrivers-webhook-testbed-21/scm
- Validation report: workspace://derekrivers-webhook-testbed-21-workspace/artifacts/validation-report.md

### Summary

The repository already contains a working Phaser 3 farm-slice prototype with grid movement, tile-based interaction, checked-in Tiled assets, and a solid local validation workflow, but the top-level README is still mostly a starter-style setup document. The best direction is to expand `README.md` into a more complete project guide that explains what the playable slice does, how the codebase is organized, where map and asset data live, and how contributors should validate and extend the prototype.

Review the existing `README.md` against the real codebase, especially `src/scenes/HelloFarmScene.ts`, `src/game/config.ts`, `src/config/constants.ts`, `src/systems/GridMovement.ts`, `src/systems/interaction.ts`, and the asset notes under `assets/`. Keep the existing installation and script sections, but reorganize the document so it reads like a project overview instead of a minimal starter. Add a concise "Project Overview" or similar section describing the current playable farm slice, including keyboard movement, camera follow behavior, collision handling, and the `E` interaction flow that resolves objects from the `Interactables` layer in the Tiled map. Add a "Project Structure" section that points readers to the main entrypoints and responsibilities, such as `src/main.ts`, `src/game/config.ts`, scene files, systems, tests, and `assets/`. Add a short map-editing/documentation section that clearly connects the README to `assets/maps/farm.tmj`, the `Collision` layer, and the `Interactables` object layer, since those are central to current gameplay behavior. Add a testing section or strengthen the existing workflow section by mapping the existing npm scripts to when contributors should use them. If helpful, add a small "Current limitations / next steps" section that frames the project as an early prototype without overpromising missing gameplay systems.

### Validation

Run deterministic lint and test checks for workspace derekrivers-webhook-testbed-21-workspace before review or SCM handoff.

### Acceptance Criteria

- Update the readme
