### PR TITLE
[RedDwarf] Feature Board

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,137 @@
     <title>Webhook Testbed</title>
   </head>
   <body>
-    <div id="game"></div>
+    <main class="app-shell">
+      <section class="feature-board" aria-labelledby="feature-board-title">
+        <header class="feature-board__header">
+          <p class="feature-board__eyebrow">Roadmap Preview</p>
+          <h1 id="feature-board-title">Feature Board</h1>
+          <p class="feature-board__subtitle">
+            A shared view of the experiences, systems, and polish items we plan
+            to build next. This template is ready to be populated with real
+            roadmap data later.
+          </p>
+        </header>
+
+        <div class="feature-board__groups">
+          <section class="feature-group" aria-labelledby="planned-title">
+            <div class="feature-group__heading">
+              <h2 id="planned-title">Planned</h2>
+              <span class="status-badge status-badge--planned">Queued</span>
+            </div>
+            <ul class="feature-list">
+              <li>
+                <article class="feature-card">
+                  <div class="feature-card__meta">
+                    <span class="feature-card__tag">Core Loop</span>
+                    <span class="feature-card__priority">High Impact</span>
+                  </div>
+                  <h3>Seasonal Quest Chains</h3>
+                  <p>
+                    Add a rotating set of guided objectives that highlight new
+                    mechanics and reward returning players.
+                  </p>
+                </article>
+              </li>
+              <li>
+                <article class="feature-card">
+                  <div class="feature-card__meta">
+                    <span class="feature-card__tag">Economy</span>
+                    <span class="feature-card__priority">Medium Lift</span>
+                  </div>
+                  <h3>Crafting Milestone Tracker</h3>
+                  <p>
+                    Surface recipe progress, unlock hints, and milestone rewards
+                    in a simple progression view.
+                  </p>
+                </article>
+              </li>
+            </ul>
+          </section>
+
+          <section class="feature-group" aria-labelledby="in-progress-title">
+            <div class="feature-group__heading">
+              <h2 id="in-progress-title">In Progress</h2>
+              <span class="status-badge status-badge--progress">Building</span>
+            </div>
+            <ul class="feature-list">
+              <li>
+                <article class="feature-card">
+                  <div class="feature-card__meta">
+                    <span class="feature-card__tag">UX</span>
+                    <span class="feature-card__priority">Active Sprint</span>
+                  </div>
+                  <h3>Playable Onboarding Checklist</h3>
+                  <p>
+                    Turn first-session setup into a clearer checklist with quick
+                    wins, guidance, and visible progress.
+                  </p>
+                </article>
+              </li>
+              <li>
+                <article class="feature-card">
+                  <div class="feature-card__meta">
+                    <span class="feature-card__tag">Systems</span>
+                    <span class="feature-card__priority">Prototype</span>
+                  </div>
+                  <h3>Weather-Driven Farm Bonuses</h3>
+                  <p>
+                    Experiment with daily modifiers that change yields, visuals,
+                    and recommended play patterns.
+                  </p>
+                </article>
+              </li>
+            </ul>
+          </section>
+
+          <section class="feature-group" aria-labelledby="ideas-title">
+            <div class="feature-group__heading">
+              <h2 id="ideas-title">Ideas</h2>
+              <span class="status-badge status-badge--ideas">Exploring</span>
+            </div>
+            <ul class="feature-list">
+              <li>
+                <article class="feature-card">
+                  <div class="feature-card__meta">
+                    <span class="feature-card__tag">Social</span>
+                    <span class="feature-card__priority">Future</span>
+                  </div>
+                  <h3>Neighbor Visit Snapshot</h3>
+                  <p>
+                    Share a lightweight summary of farm progress, favorite
+                    builds, and recent achievements with friends.
+                  </p>
+                </article>
+              </li>
+              <li>
+                <article class="feature-card">
+                  <div class="feature-card__meta">
+                    <span class="feature-card__tag">Customization</span>
+                    <span class="feature-card__priority">Wishlist</span>
+                  </div>
+                  <h3>Theme Presets for Build Areas</h3>
+                  <p>
+                    Save and reapply layout presets for decorative zones so
+                    players can switch moods more easily.
+                  </p>
+                </article>
+              </li>
+            </ul>
+          </section>
+        </div>
+      </section>
+
+      <section class="game-shell" aria-labelledby="game-preview-title">
+        <div class="game-shell__header">
+          <h2 id="game-preview-title">Prototype Preview</h2>
+          <p>
+            The current Phaser mount stays available below the board while the
+            roadmap content becomes the primary page experience.
+          </p>
+        </div>
+        <div id="game"></div>
+      </section>
+    </main>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,9 @@ import Phaser from "phaser";
 import { gameConfig } from "./game/config";
 import "./styles.css";
 
-const game = new Phaser.Game(gameConfig);
+const gameContainer = globalThis.document?.getElementById("game");
+const game = gameContainer ? new Phaser.Game(gameConfig) : null;
 
 window.addEventListener("beforeunload", () => {
-  game.destroy(true);
+  game?.destroy(true);
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,8 @@
   font-family: Arial, Helvetica, sans-serif;
   color: #f6fff2;
   background: #0f1f11;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 * {
@@ -12,15 +14,161 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  display: grid;
-  place-items: center;
   background: radial-gradient(circle at top, #1f4d27, #0f1f11 55%), #0f1f11;
 }
 
-#game {
-  width: min(100vw, 960px);
-  height: min(100vh, 720px);
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.app-shell {
+  width: min(1200px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 3rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.feature-board {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.feature-board__header {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 720px;
+}
+
+.feature-board__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #9ad37b;
+}
+
+.feature-board__subtitle,
+.game-shell__header p,
+.feature-card p {
+  color: #d7e9d2;
+}
+
+.feature-board__groups {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.feature-group,
+.game-shell {
+  background: rgba(12, 26, 14, 0.8);
+  border: 1px solid rgba(138, 196, 113, 0.2);
+  border-radius: 20px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(8px);
+}
+
+.feature-group {
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-group__heading,
+.feature-card__meta,
+.game-shell__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.feature-group__heading {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.feature-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-card {
+  display: grid;
+  gap: 0.75rem;
   padding: 1rem;
+  border-radius: 16px;
+  background: linear-gradient(
+    180deg,
+    rgba(42, 76, 39, 0.65),
+    rgba(22, 42, 23, 0.9)
+  );
+  border: 1px solid rgba(154, 211, 123, 0.15);
+}
+
+.feature-card__meta {
+  font-size: 0.8rem;
+  color: #b9d6a8;
+}
+
+.feature-card__tag,
+.feature-card__priority,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  letter-spacing: 0.03em;
+}
+
+.feature-card__tag {
+  background: rgba(154, 211, 123, 0.12);
+}
+
+.feature-card__priority {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.status-badge--planned {
+  background: rgba(154, 211, 123, 0.18);
+  color: #caf0b4;
+}
+
+.status-badge--progress {
+  background: rgba(255, 204, 102, 0.18);
+  color: #ffe29a;
+}
+
+.status-badge--ideas {
+  background: rgba(136, 170, 255, 0.18);
+  color: #d7e1ff;
+}
+
+.game-shell {
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.game-shell__header {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+#game {
+  width: 100%;
+  min-height: 320px;
+  padding: 0.5rem;
 }
 
 canvas {
@@ -30,4 +178,23 @@ canvas {
   border: 4px solid #274a1f;
   border-radius: 12px;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    width: min(100% - 1rem, 1200px);
+    padding: 1rem 0 2rem;
+  }
+
+  .feature-group,
+  .game-shell {
+    padding: 1rem;
+  }
+
+  .feature-group__heading,
+  .feature-card__meta,
+  .game-shell__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-webhook-testbed-23
- Run ID: 7a36234a-127b-45db-85da-c5848808542f
- Base branch: main
- Head branch: reddwarf/derekrivers-webhook-testbed-23/scm
- Validation report: workspace://derekrivers-webhook-testbed-23-workspace/artifacts/validation-report.md

### Summary

This repository is currently a single-page Vite application that bootstraps a Phaser game into `#game` from `src/main.ts`, with the only HTML shell living in `index.html`. The lowest-risk way to add a Feature Board is to implement it as a static semantic HTML template in `index.html`, styled through `src/styles.css`, using placeholder feature cards and status labels that can be populated later. This keeps the request aligned with the issue wording, avoids introducing routing or new dependencies, and preserves the existing app structure.

Update `index.html` to add a top-level Feature Board section using semantic markup such as `main`, `header`, `section`, `ul`, and `article`, with placeholder copy for upcoming features. Keep the existing `#game` mount present unless the Developer intentionally decides the board should fully replace the current visible page.

Restructure the page shell so the new Feature Board is the primary DOM content. A practical pattern is a wrapper like `.app-shell` containing a board header, a short explanatory subtitle, and one or more grouped feature lists such as `Planned`, `In Progress`, or `Ideas`, each rendered as static placeholder cards.

Style the board in `src/styles.css` rather than inlined styles. Reuse the repository’s current visual language where possible, especially the green farm-inspired palette already used for the page background. Add layout rules for responsive spacing, card styling, chip or badge variants for status, and accessible contrast for text.

Decide how the existing Phaser mount should behave on this page. The safest implementation is either to keep `#game` in the DOM but visually de-emphasize it below the board, or to hide/remove it and update `src/main.ts` so Phaser only initializes when the expected mount element exists. If `#game` is removed from the template, guard the `new Phaser.Game(gameConfig)` call behind a lookup for the container element to avoid runtime failures.

If the Developer wants a cleaner separation between game content and the Feature Board, they can create a small static HTML partial structure directly in `index.html` first, without creating a new scene or mixing this UI into Phaser. This request is best handled as normal DOM content, not as an in-canvas game scene.

### Validation

Run deterministic lint and test checks for workspace derekrivers-webhook-testbed-23-workspace before review or SCM handoff.

### Acceptance Criteria

- Create FeatureBoard template
