### PR TITLE
[RedDwarf] Test Call

### DIFF
--- a/test.html
+++ b/test.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Record</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #f3f4f6;
+        color: #111827;
+      }
+
+      main {
+        width: min(100% - 2rem, 720px);
+        background: #ffffff;
+        border-radius: 16px;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+        padding: 2rem;
+      }
+
+      h1 {
+        margin-top: 0;
+        margin-bottom: 0.5rem;
+        font-size: clamp(1.75rem, 3vw, 2.25rem);
+      }
+
+      p {
+        margin-top: 0;
+        margin-bottom: 1.5rem;
+        color: #4b5563;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        overflow: hidden;
+        border-radius: 12px;
+      }
+
+      th,
+      td {
+        padding: 0.9rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid #e5e7eb;
+      }
+
+      th {
+        background: #111827;
+        color: #ffffff;
+        font-weight: 600;
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      tbody tr:nth-child(even) {
+        background: #f9fafb;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Test Log</h1>
+      <p>This page records a simple test completion entry in a table.</p>
+
+      <table aria-label="Test completion log">
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Message</th>
+          </tr>
+        </thead>
+        <tbody id="test-log"></tbody>
+      </table>
+    </main>
+
+    <script type="module">
+      const tableBody = document.getElementById('test-log');
+      const row = document.createElement('tr');
+      const dateCell = document.createElement('td');
+      const messageCell = document.createElement('td');
+
+      const formattedDate = new Date().toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+
+      dateCell.textContent = formattedDate;
+      messageCell.textContent = 'Test completed';
+
+      row.append(dateCell, messageCell);
+      tableBody?.append(row);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## RedDwarf SCM Handoff

- Task ID: derekrivers-webhook-testbed-25
- Run ID: e4f376dd-6627-449c-8506-1ce1cd95a22a
- Base branch: main
- Head branch: reddwarf/derekrivers-webhook-testbed-25/scm
- Validation report: workspace://derekrivers-webhook-testbed-25-workspace/artifacts/validation-report.md

### Summary

This repository is a Vite + TypeScript + Phaser front-end app rooted at `index.html` with game code under `src/`, and there is no server, API, or database layer in the current checkout. The safest implementation is to add a separate static `test.html` file at the repo root that renders a simple confirmation page and includes a table showing at least one row with the current date and a "test completed" style message, implemented entirely on the client side so it fits the existing architecture without disturbing the Phaser entrypoint.

Create a new root-level `test.html` alongside the existing `index.html` so the main Phaser app entry remains untouched. Build the page as a self-contained static document with a heading, a short explanatory message, and a `<table>` element with columns for date and message. Populate the table either with a hard-coded initial row in the markup or by using a small inline script that inserts a row at page load using the browser's current date and a fixed completion message such as `Test completed`.

If the developer wants the page to behave more like a record log instead of a single static example row, they can keep the implementation front-end only by storing rows in `localStorage`, but that is optional and should only be added if the issue is interpreted as needing repeatable logging behavior. Keep styling lightweight and local to `test.html` unless there is a clear reason to extract shared styles, because the existing shared stylesheet is designed around the Phaser canvas shell.

After adding the file, verify that Vite serves it correctly from the project root and that it does not interfere with the existing `index.html` bootstrapping path that loads `/src/main.ts`.

### Validation

Run deterministic lint and test checks for workspace derekrivers-webhook-testbed-25-workspace before review or SCM handoff.

### Acceptance Criteria

- a new tets.html is cdreated according to the summary in our issue.
